### PR TITLE
Add Terms page with styled content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import Lesson from "./pages/Lesson";
 import NotFound from "./pages/NotFound";
 import NavBar from "./components/navigation/navBar";
 import Header from "./components/header/header";
-import Footer from "./components/footer/footer";
 import Registration from "./pages/auth/Registration";
 import Login from "./pages/auth/Login";
 import ForgotPassword from "./pages/auth/ForgotPassword";
@@ -16,6 +15,7 @@ import { Provider } from "react-redux";
 import { store } from "./slices/store";
 import EmailConfirmation from "./pages/auth/EmailConfirmation";
 import About from "./pages/About";
+import Terms from "./pages/Terms";
 
 function App() {
     return (
@@ -40,6 +40,7 @@ function App() {
                         <Route path="/reset-password" element={<ResetPassword />} />
                         <Route path="/password-updated" element={<PasswordUpdated/>} />
                         <Route path="/about" element={<About />} />
+                        <Route path="/terms" element={<Terms />} />
                     </Routes>
 
                     {/* <Footer /> */}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+
+export default function Terms() {
+    return (
+        <div className="terms-page">
+            <div className="terms-container">
+                <h1 className="terms-title">
+                    Terms and Conditions of Service for <span className="terms-title-accent">Young Explorers</span>
+                </h1>
+                <p className="terms-subtitle">
+                    Please note that these Terms and Conditions of Service were last revised on July 21st, 2025.
+                </p>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">1. Who can use Vembo?</h2>
+                    <p className="terms-item-description">
+                        You need to be at least 13 years old, or have permission from your parent or guardian.
+                    </p>
+                </div>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">2. Using Vembo</h2>
+                    <p className="terms-item-description">
+                        Vembo is made for learning history and having fun. Please use it only for yourself and don't try to copy or sell it. Be kind and respectful if you chat or share with others.
+                    </p>
+                </div>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">3. Premium Access</h2>
+                    <p className="terms-item-description">
+                        Some parts of Vembo are free, and some are Premium. Premium gives you extra stories, animations, and special journeys. Payments are handled safely through the app store.
+                    </p>
+                </div>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">4. Learning Materials</h2>
+                    <p className="terms-item-description">
+                        Vembo tells you facts about history, so you can learn. Vembo tries its best to be accurate, but remember that it's not the same as learning in school.
+                    </p>
+                </div>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">5. Privacy</h2>
+                    <p className="terms-item-description">
+                        We collect only a little information to help run the program and serve you better. We never sell your information and we keep your personal details safe.
+                    </p>
+                </div>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">6. Changes</h2>
+                    <p className="terms-item-description">
+                        Sometimes we will update these rules. If you keep using Vembo after changes, it means you agree to them.
+                    </p>
+                </div>
+
+                <div className="terms-item">
+                    <h2 className="terms-item-heading">7. Questions</h2>
+                    <p className="terms-item-description">
+                        If you or your parent/guardian have questions, email us at: support@vembo.app
+                    </p>
+                </div>
+
+                <div className="terms-divider" />
+
+                <p className="terms-bottom">
+                    By creating an account or using Vembo, you agree to follow these rules.
+                </p>
+            </div>
+        </div>
+    );
+}
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -820,3 +820,89 @@ body {
   line-height:normal;
   letter-spacing:-0.32px;
 }
+
+/* Terms Page */
+.terms-page{
+  width:100%;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+}
+
+.terms-container{
+  width:1069px;
+}
+
+.terms-title{
+  margin-top:47px;
+  margin-bottom:32px;
+  color:#FFF;
+  font-family:"Rubik";
+  font-size:40px;
+  font-style:normal;
+  font-weight:700;
+  line-height:normal;
+  letter-spacing:-0.4px;
+}
+
+.terms-title-accent{
+  color:var(--Glacier-Blue, #71B4D4);
+  display:block;
+}
+
+.terms-subtitle{
+  margin-top:0px;
+  margin-bottom:24px;
+  color:#FFF;
+  font-family:"Rubik";
+  font-size:24px;
+  font-style:normal;
+  font-weight:700;
+  line-height:normal;
+  letter-spacing:-0.24px;
+}
+
+.terms-item-heading{
+  margin-top:0px;
+  margin-bottom:8px;
+  color:#FFF;
+  font-family:"Rubik";
+  font-size:24px;
+  font-style:normal;
+  font-weight:700;
+  line-height:normal;
+  letter-spacing:-0.24px;
+}
+
+.terms-item-description{
+  margin-top:0px;
+  margin-bottom:16px;
+  color:#FFF;
+  font-family:"Rubik";
+  font-size:24px;
+  font-style:normal;
+  font-weight:400;
+  line-height:normal;
+  letter-spacing:-0.24px;
+}
+
+.terms-divider{
+  margin-top:32px;
+  margin-bottom:40px;
+  width:1069px;
+  height:3px;
+  background:#71B4D4;
+}
+
+.terms-bottom{
+  margin-top:0px;
+  margin-bottom:102px;
+  color:#FFF;
+  font-family:"Rubik";
+  font-size:24px;
+  font-style:normal;
+  font-weight:400;
+  line-height:normal;
+  letter-spacing:-0.24px;
+}
+


### PR DESCRIPTION
## Summary
- add `Terms` page with centered Terms and Conditions layout
- style Terms page typography and divider in global stylesheet
- register `/terms` route for new page