### PR TITLE
Fix settings profile sidebar responsive overflow

### DIFF
--- a/src/styles/settings/layout.css
+++ b/src/styles/settings/layout.css
@@ -58,8 +58,9 @@
 }
 
 .sidebar-right {
-    width: var(--rightbar-width);
-    padding: 100px 70px 0px;
+    width: min(var(--rightbar-width), 100%);
+    box-sizing: border-box;
+    padding: 100px clamp(24px, 5vw, 70px) 32px;
     display: flex;
     flex-direction: column;
     gap: 24px;
@@ -68,7 +69,15 @@
     top: 0;
     bottom: 0;
     height: 100vh;
+    overflow-y: auto;
     z-index: 40;
+}
+
+@media (max-width: 1440px) {
+    .sidebar-right {
+        padding-top: 80px;
+        padding-bottom: 32px;
+    }
 }
 
 .settings-card {


### PR DESCRIPTION
## Summary
- adjust the settings sidebar styling so navigation and logout controls remain within the panel across viewports
- add responsive padding and vertical scrolling to the sidebar to prevent elements from overflowing on shorter screens


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Sidebar now respects the viewport width to prevent overflow.
  * Enabled internal vertical scrolling in the sidebar for long content.
  * Introduced responsive horizontal padding (clamped) and added bottom padding for improved layout.
  * Adjusted top/bottom padding at narrower viewports (≤1440px) for better spacing and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->