### PR TITLE
Improve responsive layout and mobile navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,9 +43,12 @@ function App() {
     const [userStatistic, setUserStatistic] = useState<UserStatisticDTO | null>();
     const isNavbarHidden = useSelector(selectIsNavbarHidden);
     const isSidebarHidden = useSelector(selectIsSidebarHidden);
-    const [gridTemplateFirstColumn, setGridTemplateFirstColumn] = useState("320px");
+    const [gridTemplateFirstColumn, setGridTemplateFirstColumn] = useState("320px 5fr");
     const [gridTemplateThirdColumn, setGridTemplateThirdColumn] = useState("3fr");
-    const gridTemplateColumns = `${gridTemplateFirstColumn} ${gridTemplateThirdColumn}`;
+    const [isMobileLayout, setIsMobileLayout] = useState<boolean>(false);
+    const gridTemplateColumns = isMobileLayout
+        ? "minmax(0, 1fr)"
+        : `${gridTemplateFirstColumn} ${gridTemplateThirdColumn}`;
     const isWhatAreLeaderboardsCard = useSelector(selectIsWhatAreLeaderboardsCardHidden);
     const navigate = useNavigate();
     const token = useSelector(selectToken);
@@ -74,6 +77,27 @@ function App() {
     }, [dispatch]);
 
     useEffect(() => {
+        const updateLayoutMode = () => {
+            if (typeof window === "undefined") return;
+
+            setIsMobileLayout(window.innerWidth <= 1024);
+        };
+
+        updateLayoutMode();
+
+        window.addEventListener("resize", updateLayoutMode);
+
+        return () => window.removeEventListener("resize", updateLayoutMode);
+    }, []);
+
+    useEffect(() => {
+        if (isMobileLayout) {
+            setGridTemplateFirstColumn("1fr");
+            setGridTemplateThirdColumn("auto");
+
+            return;
+        }
+
         if (isNavbarHidden) {
             setGridTemplateFirstColumn("1fr");
         } else {
@@ -85,7 +109,7 @@ function App() {
         } else {
             setGridTemplateThirdColumn("3fr");
         }
-    });
+    }, [isNavbarHidden, isSidebarHidden, isMobileLayout]);
 
     const checkIsTokenValid = async () => {
         if (!token) return false;
@@ -161,19 +185,19 @@ function App() {
 
     return (
         <div
-            className="grid-container"
+            className={`grid-container ${isMobileLayout ? "grid-container-mobile" : ""}`}
             style={{
                 gridTemplateColumns: `${gridTemplateColumns}`,
                 ["--grid-background" as any]: `${
-                    !isWhatAreLeaderboardsCard && !isSidebarHidden
+                    !isMobileLayout && !isWhatAreLeaderboardsCard && !isSidebarHidden
                         ? "linear-gradient(to bottom, transparent 75%, rgba(0, 0, 0, 0.4) 100%)"
                         : "none"
                 }`,
             }}
         >
-            <NavBar isHidden={isNavbarHidden} />
+            <NavBar isHidden={isNavbarHidden} isMobileLayout={isMobileLayout} />
 
-            <div className="container">
+            <div className={`container ${isMobileLayout ? "container-mobile" : ""}`}>
                 <Routes>
                     <Route path="*" element={<NotFound />} />
                     <Route path="/" element={<Home />} />
@@ -204,8 +228,8 @@ function App() {
                     <Route path="/get-insight" element={<Premium />} />
                 </Routes>
             </div>
-
-            <Sidebar isHidden={isSidebarHidden} />
+            {isMobileLayout ? null : <Sidebar isHidden={isSidebarHidden} />}
+            {isMobileLayout ? <Sidebar isHidden={isSidebarHidden} /> : null}
         </div>
     );
 }

--- a/src/components/navigation/navBar.tsx
+++ b/src/components/navigation/navBar.tsx
@@ -1,17 +1,24 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { logout, selectUserData } from "../../slices/authSlice";
 import { useDispatch, useSelector } from "react-redux";
 import type { NavbarComponent } from "../../types/componentTypes";
 import { selectSelectedPage } from "../../slices/menuSlice";
 
-export default function NavBar({ isHidden }: NavbarComponent) {
+export default function NavBar({ isHidden, isMobileLayout = false }: NavbarComponent) {
     const user = useSelector(selectUserData);
     const selectedPage = useSelector(selectSelectedPage);
 
     const [moreOpen, setMoreOpen] = useState(false);
-    const hideTimeoutRef = useRef<any>(null);
+    const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+    const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const dispatch = useDispatch();
+
+    useEffect(() => {
+        if (!isMobileLayout) {
+            setIsDrawerOpen(false);
+        }
+    }, [isMobileLayout]);
 
     const openMore = () => {
         if (hideTimeoutRef.current) {
@@ -20,6 +27,10 @@ export default function NavBar({ isHidden }: NavbarComponent) {
         }
 
         setMoreOpen(true);
+    };
+
+    const toggleMore = () => {
+        setMoreOpen((prev) => !prev);
     };
 
     const blockHide = () => {
@@ -43,73 +54,156 @@ export default function NavBar({ isHidden }: NavbarComponent) {
         dispatch(logout());
     };
 
+    const handleDrawerToggle = () => {
+        if (!isMobileLayout) return;
+
+        setIsDrawerOpen((prev) => !prev);
+        setMoreOpen(false);
+    };
+
+    const handleDrawerClose = () => {
+        if (!isMobileLayout) return;
+
+        setIsDrawerOpen(false);
+        setMoreOpen(false);
+    };
+
+    const handleNavInteraction = () => {
+        if (isMobileLayout) {
+            handleDrawerClose();
+        } else {
+            closeMoreImmediately();
+        }
+    };
+
     return (
-        <nav className={`navbar ${isHidden ? "hidden" : ""}`} onClick={closeMoreImmediately}>
-            <Link to="/" className="nav-title">
-                Vembo
-            </Link>
-            <Link to="/" className={`nav-btn ${selectedPage === 0 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/glacier.png" />
-                Learn
-            </Link>
-            <Link to="/practice-hub" className={`nav-btn ${selectedPage === 1 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/practice.png" />
-                Practice
-            </Link>
-            <Link to="/leaderboards" className={`nav-btn ${selectedPage === 2 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/leaderboards.png" />
-                Leaderboards
-            </Link>
-            <Link to="/quests" className={`nav-btn ${selectedPage === 3 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/chest.png" />
-                Quests
-            </Link>
-            <Link to="/shop" className={`nav-btn ${selectedPage === 4 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/shop.png" />
-                Shop
-            </Link>
-            <Link
-                to={`/profile/${user?.nickName}`}
-                className={`nav-btn ${selectedPage === 5 ? "nav-btn-selected" : ""}`}
+        <>
+            <nav
+                id="vembo-navigation"
+                className={`navbar ${isHidden ? "hidden" : ""} ${isMobileLayout ? "navbar-drawer" : ""} ${
+                    isMobileLayout && isDrawerOpen ? "navbar-drawer-open" : ""
+                }`}
+                onClick={!isMobileLayout ? closeMoreImmediately : undefined}
+                aria-hidden={isMobileLayout ? !isDrawerOpen : undefined}
             >
-                <img
-                    className="nav-profile-icon"
-                    src={user?.avatarUrl ? user?.avatarUrl : "/src/assets/icons/profile_default_icon.png"}
-                />
-                Profile
-            </Link>
-
-            <div className="nav-btn more-container" onMouseEnter={openMore} onMouseLeave={closeMore}>
-                <div className="more-toggle">
-                    <img className="nav-icon" src="/src/assets/icons/more.png" />
-                    <span>More</span>
-                </div>
-
-                <div
-                    className={`more-menu ${moreOpen ? "more-menu-open" : "more-menu-closed"}`}
-                    onMouseEnter={blockHide}
-                    role="menu"
-                    aria-hidden={!moreOpen}
-                >
-                    <Link to="/settings" className="more-menu-item" onClick={closeMoreImmediately}>
-                        Settings
+                <div className="navbar-scrollable">
+                    <Link to="/" className="nav-title" onClick={handleNavInteraction}>
+                        Vembo
+                    </Link>
+                    <Link
+                        to="/"
+                        className={`nav-btn ${selectedPage === 0 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavInteraction}
+                    >
+                        <img className="nav-icon" src="/src/assets/icons/glacier.png" />
+                        Learn
+                    </Link>
+                    <Link
+                        to="/practice-hub"
+                        className={`nav-btn ${selectedPage === 1 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavInteraction}
+                    >
+                        <img className="nav-icon" src="/src/assets/icons/practice.png" />
+                        Practice
+                    </Link>
+                    <Link
+                        to="/leaderboards"
+                        className={`nav-btn ${selectedPage === 2 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavInteraction}
+                    >
+                        <img className="nav-icon" src="/src/assets/icons/leaderboards.png" />
+                        Leaderboards
+                    </Link>
+                    <Link
+                        to="/quests"
+                        className={`nav-btn ${selectedPage === 3 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavInteraction}
+                    >
+                        <img className="nav-icon" src="/src/assets/icons/chest.png" />
+                        Quests
+                    </Link>
+                    <Link
+                        to="/shop"
+                        className={`nav-btn ${selectedPage === 4 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavInteraction}
+                    >
+                        <img className="nav-icon" src="/src/assets/icons/shop.png" />
+                        Shop
+                    </Link>
+                    <Link
+                        to={`/profile/${user?.nickName}`}
+                        className={`nav-btn ${selectedPage === 5 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavInteraction}
+                    >
+                        <img
+                            className="nav-profile-icon"
+                            src={user?.avatarUrl ? user?.avatarUrl : "/src/assets/icons/profile_default_icon.png"}
+                        />
+                        Profile
                     </Link>
 
                     <div
-                        className="more-menu-item"
-                        onClick={() => {
-                            handleLogout();
-                            closeMoreImmediately();
-                        }}
+                        className="nav-btn more-container"
+                        onMouseEnter={!isMobileLayout ? openMore : undefined}
+                        onMouseLeave={!isMobileLayout ? closeMore : undefined}
                     >
-                        Log out
-                    </div>
+                        <button
+                            type="button"
+                            className="more-toggle"
+                            onClick={isMobileLayout ? toggleMore : undefined}
+                            aria-expanded={moreOpen}
+                            aria-haspopup="true"
+                        >
+                            <img className="nav-icon" src="/src/assets/icons/more.png" />
+                            <span>More</span>
+                        </button>
 
-                    <Link to="/help" className="more-menu-item" onClick={closeMoreImmediately}>
-                        Help
-                    </Link>
+                        <div
+                            className={`more-menu ${moreOpen ? "more-menu-open" : "more-menu-closed"}`}
+                            onMouseEnter={!isMobileLayout ? blockHide : undefined}
+                            role="menu"
+                            aria-hidden={!moreOpen}
+                        >
+                            <Link to="/settings" className="more-menu-item" onClick={handleNavInteraction}>
+                                Settings
+                            </Link>
+
+                            <button
+                                type="button"
+                                className="more-menu-item"
+                                onClick={() => {
+                                    handleLogout();
+                                    handleNavInteraction();
+                                }}
+                            >
+                                Log out
+                            </button>
+
+                            <Link to="/help" className="more-menu-item" onClick={handleNavInteraction}>
+                                Help
+                            </Link>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </nav>
+            </nav>
+
+            {isMobileLayout ? (
+                <>
+                    <button
+                        type="button"
+                        className={`navbar-toggle ${isDrawerOpen ? "navbar-toggle-open" : ""}`}
+                        onClick={handleDrawerToggle}
+                        aria-expanded={isDrawerOpen}
+                        aria-controls="vembo-navigation"
+                        aria-label={isDrawerOpen ? "Close navigation" : "Open navigation"}
+                    >
+                        <span />
+                        <span />
+                        <span />
+                    </button>
+                    {isDrawerOpen ? <div className="navbar-overlay" onClick={handleDrawerClose} /> : null}
+                </>
+            ) : null}
+        </>
     );
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -190,6 +190,9 @@ button:not(:disabled):active {
     width: 100%;
     align-items: center;
     flex-direction: column;
+    padding: 40px 48px 56px;
+    gap: 32px;
+    box-sizing: border-box;
 }
 
 body.settings-page .container {
@@ -228,6 +231,24 @@ body.settings-page .container {
     height: 100vh;
     border-right: 1px solid var(--ice-white);
     background-color: var(--polar-navy);
+}
+
+.navbar-scrollable {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 32px 24px;
+    gap: 12px;
+    overflow-y: auto;
+}
+
+.navbar-scrollable::-webkit-scrollbar {
+    width: 6px;
+}
+
+.navbar-scrollable::-webkit-scrollbar-thumb {
+    background-color: rgba(113, 180, 212, 0.4);
+    border-radius: 999px;
 }
 
 .nav-title {
@@ -296,6 +317,12 @@ body.settings-page .container {
     align-items: center;
     gap: 8px;
     width: 100%;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    padding: 0;
+    cursor: pointer;
 }
 
 .more-menu {
@@ -338,6 +365,7 @@ body.settings-page .container {
     text-align: center;
     font-size: 20px;
     font-weight: 700;
+    background: none;
 }
 
 .more-menu-item[type="button"] {
@@ -348,6 +376,60 @@ body.settings-page .container {
 .more-menu-item:hover,
 .more-menu-item:focus {
     background-color: rgba(255, 255, 255, 0.06);
+}
+
+.navbar-toggle {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    z-index: 40;
+    display: none;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    border: none;
+    background: var(--glacier-blue);
+    box-shadow: 0 16px 30px rgba(15, 32, 56, 0.25);
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    cursor: pointer;
+}
+
+.navbar-toggle span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--polar-navy);
+    display: block;
+}
+
+.navbar-toggle-open {
+    background: var(--ice-white);
+}
+
+.navbar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 32, 56, 0.55);
+    z-index: 30;
+}
+
+.navbar-drawer {
+    position: fixed;
+    top: 0;
+    left: -110%;
+    width: min(320px, 82vw);
+    height: 100dvh;
+    transition: left 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: 0 24px 48px rgba(15, 32, 56, 0.45);
+    pointer-events: none;
+    z-index: 35;
+}
+
+.navbar-drawer-open {
+    left: 0;
+    pointer-events: auto;
 }
 
 /* =========================================================================================================================================================================== */
@@ -596,6 +678,15 @@ body.hide-sidebar .sidebar-top {
     pointer-events: none !important;
 }
 
+.grid-container-mobile {
+    grid-template-columns: minmax(0, 1fr) !important;
+    min-height: 100vh;
+}
+
+.grid-container-mobile .container {
+    width: 100%;
+}
+
 /* =========================================================================================================================================================================== */
 /* ================================================================================= Statistic =============================================================================== */
 /* =========================================================================================================================================================================== */
@@ -634,6 +725,190 @@ body.hide-sidebar .sidebar-top {
     margin-top: 32px;
     flex-direction: column;
     gap: 24px;
+}
+
+/* =============================================================================================================================
+============================================== */
+/* ================================================================================= Responsive ===============================
+============================================== */
+/* =============================================================================================================================
+============================================== */
+
+@media (max-width: 1280px) {
+    .container {
+        padding: 40px 32px 56px;
+    }
+
+    .unit-header-card {
+        width: min(100%, 700px);
+    }
+}
+
+@media (max-width: 1024px) {
+    .navbar {
+        border-right: none;
+        height: 100dvh;
+    }
+
+    .navbar-scrollable {
+        padding: 64px 24px 32px;
+    }
+
+    .navbar-toggle {
+        display: flex;
+    }
+
+    .nav-title {
+        margin: 16px 0 24px;
+        margin-left: 0;
+        text-align: center;
+        width: 100%;
+    }
+
+    .nav-btn {
+        width: 100%;
+        height: auto;
+        margin: 6px 0;
+        padding: 16px 20px;
+        justify-content: flex-start;
+        gap: 16px;
+        align-self: stretch;
+    }
+
+    .nav-icon {
+        margin-left: 0;
+        margin-right: 16px;
+        width: 42px;
+    }
+
+    .nav-profile-icon {
+        margin-left: 0;
+        margin-right: 16px;
+    }
+
+    .more-container {
+        width: 100%;
+    }
+
+    .more-menu {
+        position: relative;
+        top: 0;
+        left: 0;
+        width: 100%;
+        margin-top: 12px;
+        padding: 12px 0;
+        transform: none;
+        box-shadow: 0 16px 32px rgba(15, 32, 56, 0.35);
+    }
+
+    .more-menu-open {
+        display: block;
+        opacity: 1;
+        transform: none;
+    }
+
+    .more-menu-closed {
+        display: none;
+        visibility: hidden;
+        opacity: 0;
+        transform: none;
+    }
+
+    .more-menu-item {
+        padding: 12px 24px;
+    }
+
+    .container {
+        align-items: stretch;
+        padding: 96px 20px 48px;
+    }
+
+    .unit-header-card {
+        width: 100%;
+        min-height: auto;
+    }
+
+    .unit-header {
+        flex-direction: column;
+        align-items: flex-start;
+        margin: 0;
+        padding: 24px;
+        gap: 16px;
+    }
+
+    .unit-header__title {
+        width: 100%;
+        font-size: 26px;
+        line-height: 1.35;
+    }
+
+    .unit-header__guidebook-btn {
+        width: 100%;
+        height: auto;
+        padding: 16px;
+    }
+
+    .unit-container {
+        top: 0;
+    }
+
+    .unit-title-container {
+        flex-direction: column;
+        margin-top: 40px;
+        gap: 12px;
+    }
+
+    .unit-title-container__h2 {
+        text-align: center;
+        white-space: normal;
+    }
+
+    .sidebar-top {
+        width: 100%;
+        position: static;
+        padding-top: 0;
+        margin-top: 32px;
+    }
+
+    .sidebar {
+        position: static;
+    }
+}
+
+@media (max-width: 768px) {
+    .navbar-scrollable {
+        padding: 56px 20px 32px;
+    }
+
+    .nav-title {
+        font-size: 36px;
+    }
+
+    .nav-btn {
+        font-size: 16px;
+        padding: 14px 18px;
+    }
+
+    .nav-icon {
+        width: 36px;
+        margin-right: 12px;
+    }
+
+    .nav-profile-icon {
+        width: 36px;
+    }
+
+    .more-menu-item {
+        font-size: 18px;
+    }
+
+    .container {
+        padding: 88px 16px 40px;
+    }
+
+    .unit-header__title {
+        font-size: 24px;
+    }
 }
 
 /* =========================================================================================================================================================================== */

--- a/src/types/componentTypes.ts
+++ b/src/types/componentTypes.ts
@@ -186,6 +186,7 @@ export interface unitHeaderCardComponent {
 
 export interface NavbarComponent {
     isHidden: boolean;
+    isMobileLayout?: boolean;
 }
 
 export interface SidebarComponent {


### PR DESCRIPTION
## Summary
- detect mobile breakpoints in the app shell and stack sidebar content after the main view for small screens
- add a drawer-based navigation menu triggered by a three-dot toggle and ensure links close the drawer on selection
- update global styles so cards, headers, and sidebars scale cleanly across tablet and phone breakpoints