### PR TITLE
Make navigation mobile-first and responsive

### DIFF
--- a/src/components/navigation/navBar.tsx
+++ b/src/components/navigation/navBar.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { logout, selectUserData } from "../../slices/authSlice";
 import { useDispatch, useSelector } from "react-redux";
@@ -10,6 +10,8 @@ export default function NavBar({ isHidden }: NavbarComponent) {
     const selectedPage = useSelector(selectSelectedPage);
 
     const [moreOpen, setMoreOpen] = useState(false);
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const [isDesktop, setIsDesktop] = useState(false);
     const hideTimeoutRef = useRef<any>(null);
     const dispatch = useDispatch();
 
@@ -36,80 +38,289 @@ export default function NavBar({ isHidden }: NavbarComponent) {
     };
 
     const closeMoreImmediately = () => {
+        if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current);
+            hideTimeoutRef.current = null;
+        }
+
         setMoreOpen(false);
+    };
+
+    const toggleMore = () => {
+        blockHide();
+        setMoreOpen((prev) => !prev);
+    };
+
+    const toggleMobileMenu = () => {
+        setIsMobileMenuOpen((prev) => !prev);
+    };
+
+    const closeMobileMenu = () => {
+        setIsMobileMenuOpen(false);
+    };
+
+    const handleNavLinkClick = () => {
+        closeMobileMenu();
+        closeMoreImmediately();
     };
 
     const handleLogout = () => {
         dispatch(logout());
     };
 
-    return (
-        <nav className={`navbar ${isHidden ? "hidden" : ""}`} onClick={closeMoreImmediately}>
-            <Link to="/" className="nav-title">
-                Vembo
-            </Link>
-            <Link to="/" className={`nav-btn ${selectedPage === 0 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/glacier.png" />
-                Learn
-            </Link>
-            <Link to="/practice-hub" className={`nav-btn ${selectedPage === 1 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/practice.png" />
-                Practice
-            </Link>
-            <Link to="/leaderboards" className={`nav-btn ${selectedPage === 2 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/leaderboards.png" />
-                Leaderboards
-            </Link>
-            <Link to="/quests" className={`nav-btn ${selectedPage === 3 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/chest.png" />
-                Quests
-            </Link>
-            <Link to="/shop" className={`nav-btn ${selectedPage === 4 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/shop.png" />
-                Shop
-            </Link>
-            <Link
-                to={`/profile/${user?.nickName}`}
-                className={`nav-btn ${selectedPage === 5 ? "nav-btn-selected" : ""}`}
-            >
-                <img
-                    className="nav-profile-icon"
-                    src={user?.avatarUrl ? user?.avatarUrl : "/src/assets/icons/profile_default_icon.png"}
-                />
-                Profile
-            </Link>
+    useEffect(() => {
+        if (typeof window === "undefined") return;
 
-            <div className="nav-btn more-container" onMouseEnter={openMore} onMouseLeave={closeMore}>
-                <div className="more-toggle">
-                    <img className="nav-icon" src="/src/assets/icons/more.png" />
-                    <span>More</span>
+        const mediaQuery = window.matchMedia("(min-width: 768px)");
+
+        const handleChange = (event: MediaQueryListEvent) => {
+            setIsDesktop(event.matches);
+
+            if (event.matches) {
+                setIsMobileMenuOpen(false);
+            }
+        };
+
+        if (mediaQuery.matches) {
+            setIsDesktop(true);
+            setIsMobileMenuOpen(false);
+        } else {
+            setIsDesktop(false);
+        }
+
+        if (typeof mediaQuery.addEventListener === "function") {
+            mediaQuery.addEventListener("change", handleChange);
+
+            return () => {
+                mediaQuery.removeEventListener("change", handleChange);
+            };
+        }
+
+        mediaQuery.addListener(handleChange);
+
+        return () => {
+            mediaQuery.removeListener(handleChange);
+        };
+    }, []);
+
+    useEffect(() => {
+        if (isDesktop) {
+            document.body.style.removeProperty("overflow");
+            return () => {
+                document.body.style.removeProperty("overflow");
+            };
+        }
+
+        if (isMobileMenuOpen) {
+            document.body.style.setProperty("overflow", "hidden");
+        } else {
+            document.body.style.removeProperty("overflow");
+        }
+
+        return () => {
+            document.body.style.removeProperty("overflow");
+        };
+    }, [isMobileMenuOpen, isDesktop]);
+
+    useEffect(() => {
+        if (!isMobileMenuOpen) {
+            closeMoreImmediately();
+        }
+    }, [isMobileMenuOpen]);
+
+    return (
+        <>
+            <nav className={`navbar ${isHidden ? "hidden" : ""} ${isMobileMenuOpen ? "navbar--open" : ""}`}>
+                <div className="navbar__bar">
+                    <Link to="/" className="nav-title" onClick={handleNavLinkClick}>
+                        Vembo
+                    </Link>
+
+                    <button
+                        type="button"
+                        className="nav__toggle"
+                        aria-expanded={isMobileMenuOpen}
+                        aria-controls="primary-navigation"
+                        onClick={toggleMobileMenu}
+                    >
+                        <span className="sr-only">{isMobileMenuOpen ? "Close navigation" : "Open navigation"}</span>
+                        <svg
+                            aria-hidden="true"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                            className="nav__toggle-icon"
+                        >
+                            {isMobileMenuOpen ? (
+                                <path
+                                    d="M6 6l12 12M6 18L18 6"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                />
+                            ) : (
+                                <path
+                                    d="M4 7h16M4 12h16M4 17h16"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                    strokeLinecap="round"
+                                />
+                            )}
+                        </svg>
+                    </button>
                 </div>
 
                 <div
-                    className={`more-menu ${moreOpen ? "more-menu-open" : "more-menu-closed"}`}
-                    onMouseEnter={blockHide}
+                    id="primary-navigation"
+                    className="nav__menu"
                     role="menu"
-                    aria-hidden={!moreOpen}
+                    aria-hidden={!isDesktop && !isMobileMenuOpen}
                 >
-                    <Link to="/settings" className="more-menu-item" onClick={closeMoreImmediately}>
-                        Settings
+                    <Link
+                        to="/"
+                        className={`nav-btn ${selectedPage === 0 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavLinkClick}
+                    >
+                        <img
+                            className="nav-icon"
+                            src="/src/assets/icons/glacier.png"
+                            alt="Learn"
+                            loading="lazy"
+                        />
+                        <span>Learn</span>
+                    </Link>
+                    <Link
+                        to="/practice-hub"
+                        className={`nav-btn ${selectedPage === 1 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavLinkClick}
+                    >
+                        <img
+                            className="nav-icon"
+                            src="/src/assets/icons/practice.png"
+                            alt="Practice"
+                            loading="lazy"
+                        />
+                        <span>Practice</span>
+                    </Link>
+                    <Link
+                        to="/leaderboards"
+                        className={`nav-btn ${selectedPage === 2 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavLinkClick}
+                    >
+                        <img
+                            className="nav-icon"
+                            src="/src/assets/icons/leaderboards.png"
+                            alt="Leaderboards"
+                            loading="lazy"
+                        />
+                        <span>Leaderboards</span>
+                    </Link>
+                    <Link
+                        to="/quests"
+                        className={`nav-btn ${selectedPage === 3 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavLinkClick}
+                    >
+                        <img
+                            className="nav-icon"
+                            src="/src/assets/icons/chest.png"
+                            alt="Quests"
+                            loading="lazy"
+                        />
+                        <span>Quests</span>
+                    </Link>
+                    <Link
+                        to="/shop"
+                        className={`nav-btn ${selectedPage === 4 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavLinkClick}
+                    >
+                        <img
+                            className="nav-icon"
+                            src="/src/assets/icons/shop.png"
+                            alt="Shop"
+                            loading="lazy"
+                        />
+                        <span>Shop</span>
+                    </Link>
+                    <Link
+                        to={`/profile/${user?.nickName}`}
+                        className={`nav-btn ${selectedPage === 5 ? "nav-btn-selected" : ""}`}
+                        onClick={handleNavLinkClick}
+                    >
+                        <img
+                            className="nav-profile-icon"
+                            src={
+                                user?.avatarUrl
+                                    ? user?.avatarUrl
+                                    : "/src/assets/icons/profile_default_icon.png"
+                            }
+                            alt="Profile"
+                            loading="lazy"
+                        />
+                        <span>Profile</span>
                     </Link>
 
                     <div
-                        className="more-menu-item"
-                        onClick={() => {
-                            handleLogout();
-                            closeMoreImmediately();
-                        }}
+                        className={`nav-btn more-container ${moreOpen ? "more-container--open" : ""}`}
+                        onMouseEnter={openMore}
+                        onMouseLeave={closeMore}
                     >
-                        Log out
-                    </div>
+                        <button
+                            type="button"
+                            className="more-toggle"
+                            onClick={(event) => {
+                                event.stopPropagation();
+                                toggleMore();
+                            }}
+                            aria-expanded={moreOpen}
+                            aria-controls="more-navigation"
+                        >
+                            <img
+                                className="nav-icon"
+                                src="/src/assets/icons/more.png"
+                                alt="More"
+                                loading="lazy"
+                            />
+                            <span>More</span>
+                        </button>
 
-                    <Link to="/help" className="more-menu-item" onClick={closeMoreImmediately}>
-                        Help
-                    </Link>
+                        <div
+                            id="more-navigation"
+                            className={`more-menu ${moreOpen ? "more-menu-open" : "more-menu-closed"}`}
+                            onMouseEnter={blockHide}
+                            role="menu"
+                            aria-hidden={!moreOpen}
+                        >
+                            <Link to="/settings" className="more-menu-item" onClick={handleNavLinkClick}>
+                                Settings
+                            </Link>
+
+                            <button
+                                type="button"
+                                className="more-menu-item"
+                                onClick={() => {
+                                    handleLogout();
+                                    handleNavLinkClick();
+                                }}
+                            >
+                                Log out
+                            </button>
+
+                            <Link to="/help" className="more-menu-item" onClick={handleNavLinkClick}>
+                                Help
+                            </Link>
+                        </div>
+                    </div>
                 </div>
-            </div>
-        </nav>
+            </nav>
+
+            {isMobileMenuOpen ? (
+                <button
+                    type="button"
+                    className="nav__overlay"
+                    aria-hidden="true"
+                    tabIndex={-1}
+                    onClick={toggleMobileMenu}
+                />
+            ) : null}
+        </>
     );
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -93,6 +93,103 @@ body {
     font-family: "Rubik", sans-serif;
 }
 
+:root {
+    --container-max: 80rem;
+    --space-1: clamp(0.25rem, 0.23rem + 0.2vw, 0.5rem);
+    --space-2: clamp(0.5rem, 0.46rem + 0.4vw, 0.875rem);
+    --space-3: clamp(0.75rem, 0.68rem + 0.6vw, 1.25rem);
+    --space-4: clamp(1rem, 0.92rem + 0.8vw, 1.75rem);
+    --space-5: clamp(1.5rem, 1.38rem + 1.2vw, 2.5rem);
+    --space-6: clamp(2rem, 1.84rem + 1.6vw, 3.5rem);
+
+    --step--1: clamp(0.875rem, 0.84rem + 0.2vw, 0.95rem);
+    --step-0: clamp(1rem, 0.95rem + 0.4vw, 1.125rem);
+    --step-1: clamp(1.25rem, 1.12rem + 0.8vw, 1.5rem);
+    --step-2: clamp(1.5rem, 1.3rem + 1.2vw, 2rem);
+    --step-3: clamp(1.875rem, 1.6rem + 1.6vw, 2.75rem);
+    --step-4: clamp(2.25rem, 1.85rem + 2vw, 3.25rem);
+
+    --radius-sm: 0.5rem;
+    --radius-md: 0.75rem;
+    --radius-lg: 1.25rem;
+}
+
+body {
+    font-size: var(--step-0);
+    line-height: 1.6;
+    min-block-size: 100svh;
+    display: flex;
+    flex-direction: column;
+}
+
+h1 {
+    font-size: var(--step-3);
+    line-height: 1.1;
+}
+
+h2 {
+    font-size: var(--step-2);
+    line-height: 1.2;
+}
+
+h3 {
+    font-size: var(--step-1);
+    line-height: 1.3;
+}
+
+p,
+label,
+input,
+textarea,
+select,
+button {
+    font-size: var(--step-0);
+    line-height: 1.4;
+}
+
+.container {
+    inline-size: min(100%, var(--container-max));
+    margin-inline: auto;
+    padding-inline: clamp(1rem, 3vw, 1.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+    display: block;
+    max-inline-size: 100%;
+    block-size: auto;
+}
+
+button,
+input,
+select,
+textarea {
+    min-block-size: clamp(2.5rem, 6vh, 3.25rem);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+:focus-visible {
+    outline: 3px solid var(--glacier-blue);
+    outline-offset: 3px;
+}
+
 .auth-page {
     width: 100%;
     min-height: 100vh;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -350,6 +350,335 @@ body.settings-page .container {
     background-color: rgba(255, 255, 255, 0.06);
 }
 
+/* =============================================================================================================================
+============================================== */
+/* ===================================================================== Responsive Foundation ================================
+============================================== */
+/* =============================================================================================================================
+============================================== */
+
+.grid-container {
+    --grid-background: none;
+    display: flex;
+    flex-direction: column;
+    min-block-size: 100svh;
+    background: var(--grid-background);
+    gap: var(--space-4);
+}
+
+.grid-container > .container {
+    flex: 1;
+    width: 100%;
+    padding-block: var(--space-5);
+}
+
+.navbar {
+    position: sticky;
+    top: 0;
+    z-index: 70;
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid rgba(113, 180, 212, 0.25);
+    background-color: rgba(15, 32, 56, 0.95);
+    backdrop-filter: blur(10px);
+    padding-inline: clamp(1rem, 3vw, 1.75rem);
+    padding-block: var(--space-3);
+}
+
+.navbar.hidden {
+    display: none !important;
+}
+
+.navbar__bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+}
+
+.nav-title {
+    margin: 0;
+    font-family: "Atma", sans-serif;
+    font-size: var(--step-3);
+    color: var(--nav-title-color);
+}
+
+.nav__toggle {
+    inline-size: 44px;
+    block-size: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(113, 180, 212, 0.35);
+    background: rgba(245, 250, 255, 0.08);
+    color: var(--ice-white);
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.nav__toggle:hover {
+    background: rgba(245, 250, 255, 0.16);
+}
+
+.nav__toggle-icon {
+    inline-size: 1.5rem;
+    block-size: 1.5rem;
+}
+
+.nav__menu {
+    position: fixed;
+    inset: 0;
+    top: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding-inline: clamp(1.25rem, 4vw, 2rem);
+    padding-block: calc(var(--space-6) + 3.5rem);
+    background: rgba(15, 32, 56, 0.98);
+    transform: translateY(-110%);
+    opacity: 0;
+    pointer-events: none;
+    transition: transform 0.35s ease, opacity 0.35s ease;
+    overflow-y: auto;
+}
+
+.navbar--open .nav__menu {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.nav__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 32, 56, 0.55);
+    border: none;
+    padding: 0;
+    margin: 0;
+    z-index: 60;
+}
+
+.nav__overlay:hover {
+    cursor: pointer;
+}
+
+.nav-btn {
+    width: 100%;
+    margin: 0;
+    padding: var(--space-2) var(--space-3);
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: var(--space-2);
+    min-block-size: clamp(3.25rem, 7vh, 3.75rem);
+    font-size: var(--step-0);
+    border-radius: var(--radius-lg);
+    border-width: 2px;
+    border-style: solid;
+    border-color: var(--nav-btn-border-color);
+    background-color: transparent;
+    color: var(--ice-white);
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-btn:hover {
+    transform: translateY(-2px);
+    border-color: var(--nav-btn-border-color-hover);
+    background-color: rgba(245, 250, 255, 0.12);
+}
+
+.nav-btn-selected {
+    border-color: var(--nav-btn-border-color-active);
+    background-color: rgba(113, 180, 212, 0.2);
+}
+
+.nav-icon {
+    margin: 0;
+    inline-size: clamp(2.25rem, 1.9rem + 1vw, 3.25rem);
+    block-size: clamp(2.25rem, 1.9rem + 1vw, 3.25rem);
+    object-fit: contain;
+}
+
+.nav-profile-icon {
+    inline-size: clamp(2.25rem, 1.9rem + 1vw, 3.25rem);
+    block-size: clamp(2.25rem, 1.9rem + 1vw, 3.25rem);
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.more-container {
+    position: relative;
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-2);
+}
+
+.more-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    width: 100%;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    padding: 0;
+    cursor: pointer;
+}
+
+.more-menu {
+    width: 100%;
+    border: 1px solid var(--glacier-blue);
+    border-radius: var(--radius-lg);
+    background-color: rgba(15, 32, 56, 0.98);
+    padding: var(--space-2) var(--space-3);
+    box-shadow: 0 1.5rem 3rem -1.5rem rgba(12, 26, 46, 0.7);
+}
+
+.more-menu-open {
+    display: grid;
+    gap: var(--space-1);
+}
+
+.more-menu-closed {
+    display: none;
+}
+
+.more-menu-item {
+    display: block;
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    border: none;
+    background: transparent;
+    color: var(--ice-white);
+    font-weight: 600;
+    text-transform: uppercase;
+    text-align: left;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.more-menu-item:hover,
+.more-menu-item:focus-visible {
+    background-color: rgba(113, 180, 212, 0.16);
+    color: var(--ice-white);
+}
+
+.sidebar-top {
+    width: 100%;
+    position: static;
+    padding-top: var(--space-5);
+    margin-inline: auto;
+}
+
+.sidebar {
+    width: 100%;
+    position: static;
+}
+
+@media (min-width: 768px) {
+    .navbar {
+        padding-inline: clamp(1.25rem, 2vw, 2rem);
+        padding-block: var(--space-5);
+        border-bottom: none;
+        border-right: 1px solid rgba(113, 180, 212, 0.25);
+        height: 100vh;
+        max-inline-size: 20.5rem;
+    }
+
+    .navbar__bar {
+        display: none;
+    }
+
+    .nav__menu {
+        position: static;
+        transform: none;
+        opacity: 1;
+        pointer-events: auto;
+        padding: 0;
+        gap: var(--space-2);
+        background: transparent;
+        height: 100%;
+    }
+
+    .nav-btn {
+        margin-inline: auto;
+    }
+
+    .more-container {
+        align-self: stretch;
+    }
+
+    .more-menu {
+        position: absolute;
+        top: 0;
+        inset-inline-start: calc(100% + var(--space-2));
+        width: clamp(14rem, 18vw, 16rem);
+        padding: var(--space-3);
+        opacity: 0;
+        visibility: hidden;
+        transform: translateY(-10%) scale(0.96);
+        transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+
+    .more-menu-open {
+        display: block;
+        opacity: 1;
+        visibility: visible;
+        transform: translateY(0) scale(1);
+    }
+
+    .more-menu-closed {
+        display: block;
+        pointer-events: none;
+    }
+}
+
+@media (min-width: 1024px) {
+    .grid-container {
+        display: grid;
+        grid-template-columns: inherit;
+        align-items: start;
+        gap: var(--space-5);
+    }
+
+    .navbar {
+        grid-column: 1;
+    }
+
+    .grid-container > .container {
+        grid-column: 2;
+        padding-block: var(--space-6);
+    }
+
+    .sidebar-top {
+        grid-column: 3;
+        position: sticky;
+        top: var(--space-5);
+        padding-top: var(--space-6);
+        max-inline-size: 26rem;
+    }
+
+    .sidebar {
+        position: sticky;
+        top: var(--space-5);
+    }
+}
+
+@media (min-width: 1280px) {
+    .grid-container {
+        gap: var(--space-6);
+    }
+
+    .nav-btn {
+        font-size: var(--step-1);
+    }
+}
+
 /* =========================================================================================================================================================================== */
 /* ============================================================================== Unit Header Card ============================================================================ */
 /* =========================================================================================================================================================================== */


### PR DESCRIPTION
## Summary
- redesign the main navigation to support a mobile-first slide-in menu with accessible controls and lazy-loaded icons
- add fluid spacing and typography variables plus an adaptive container utility to keep layouts breathable across breakpoints
- refresh grid, sidebar, and navigation styles to eliminate fixed widths and enable responsive Duolingo-inspired layout shifts