### PR TITLE
Refactor layout for mobile-first responsiveness

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,9 +43,15 @@ function App() {
     const [userStatistic, setUserStatistic] = useState<UserStatisticDTO | null>();
     const isNavbarHidden = useSelector(selectIsNavbarHidden);
     const isSidebarHidden = useSelector(selectIsSidebarHidden);
-    const [gridTemplateFirstColumn, setGridTemplateFirstColumn] = useState("320px");
-    const [gridTemplateThirdColumn, setGridTemplateThirdColumn] = useState("3fr");
-    const gridTemplateColumns = `${gridTemplateFirstColumn} ${gridTemplateThirdColumn}`;
+    const [gridTemplateFirstColumn, setGridTemplateFirstColumn] = useState(
+        "minmax(clamp(14rem, 24vw, 18rem), 1fr)"
+    );
+    const [gridTemplateThirdColumn, setGridTemplateThirdColumn] = useState(
+        "minmax(clamp(17rem, 28vw, 22rem), 1fr)"
+    );
+    const gridTemplateColumns = [gridTemplateFirstColumn, "minmax(0, 5fr)", gridTemplateThirdColumn]
+        .filter(Boolean)
+        .join(" ");
     const isWhatAreLeaderboardsCard = useSelector(selectIsWhatAreLeaderboardsCardHidden);
     const navigate = useNavigate();
     const token = useSelector(selectToken);
@@ -75,15 +81,15 @@ function App() {
 
     useEffect(() => {
         if (isNavbarHidden) {
-            setGridTemplateFirstColumn("1fr");
+            setGridTemplateFirstColumn("");
         } else {
-            setGridTemplateFirstColumn("320px 5fr");
+            setGridTemplateFirstColumn("minmax(clamp(14rem, 24vw, 18rem), 1fr)");
         }
 
         if (isSidebarHidden) {
-            setGridTemplateThirdColumn("auto");
+            setGridTemplateThirdColumn("");
         } else {
-            setGridTemplateThirdColumn("3fr");
+            setGridTemplateThirdColumn("minmax(clamp(17rem, 28vw, 22rem), 1fr)");
         }
     });
 
@@ -162,8 +168,10 @@ function App() {
     return (
         <div
             className="grid-container"
+            data-sidebar-hidden={isSidebarHidden}
+            data-nav-hidden={isNavbarHidden}
             style={{
-                gridTemplateColumns: `${gridTemplateColumns}`,
+                ["--app-grid-template" as any]: gridTemplateColumns || undefined,
                 ["--grid-background" as any]: `${
                     !isWhatAreLeaderboardsCard && !isSidebarHidden
                         ? "linear-gradient(to bottom, transparent 75%, rgba(0, 0, 0, 0.4) 100%)"

--- a/src/components/navigation/navBar.tsx
+++ b/src/components/navigation/navBar.tsx
@@ -10,7 +10,8 @@ export default function NavBar({ isHidden }: NavbarComponent) {
     const selectedPage = useSelector(selectSelectedPage);
 
     const [moreOpen, setMoreOpen] = useState(false);
-    const hideTimeoutRef = useRef<any>(null);
+    const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+    const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const dispatch = useDispatch();
 
     const openMore = () => {
@@ -35,79 +36,184 @@ export default function NavBar({ isHidden }: NavbarComponent) {
         }, 1000);
     };
 
+    const toggleMore = () => {
+        if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current);
+            hideTimeoutRef.current = null;
+        }
+
+        setMoreOpen((previous) => !previous);
+    };
+
     const closeMoreImmediately = () => {
+        if (hideTimeoutRef.current) {
+            clearTimeout(hideTimeoutRef.current);
+            hideTimeoutRef.current = null;
+        }
+
         setMoreOpen(false);
+    };
+
+    const closeMobileMenu = () => {
+        setIsMobileMenuOpen(false);
+    };
+
+    const toggleMobileMenu = () => {
+        setIsMobileMenuOpen((previous) => !previous);
+    };
+
+    const handleNavItemClick = () => {
+        closeMobileMenu();
+        closeMoreImmediately();
     };
 
     const handleLogout = () => {
         dispatch(logout());
     };
 
+    const navClasses = ["navbar"];
+
+    if (isHidden) {
+        navClasses.push("hidden");
+    }
+
+    if (isMobileMenuOpen) {
+        navClasses.push("is-open");
+    }
+
     return (
-        <nav className={`navbar ${isHidden ? "hidden" : ""}`} onClick={closeMoreImmediately}>
-            <Link to="/" className="nav-title">
-                Vembo
-            </Link>
-            <Link to="/" className={`nav-btn ${selectedPage === 0 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/glacier.png" />
-                Learn
-            </Link>
-            <Link to="/practice-hub" className={`nav-btn ${selectedPage === 1 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/practice.png" />
-                Practice
-            </Link>
-            <Link to="/leaderboards" className={`nav-btn ${selectedPage === 2 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/leaderboards.png" />
-                Leaderboards
-            </Link>
-            <Link to="/quests" className={`nav-btn ${selectedPage === 3 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/chest.png" />
-                Quests
-            </Link>
-            <Link to="/shop" className={`nav-btn ${selectedPage === 4 ? "nav-btn-selected" : ""}`}>
-                <img className="nav-icon" src="/src/assets/icons/shop.png" />
-                Shop
-            </Link>
-            <Link
-                to={`/profile/${user?.nickName}`}
-                className={`nav-btn ${selectedPage === 5 ? "nav-btn-selected" : ""}`}
-            >
-                <img
-                    className="nav-profile-icon"
-                    src={user?.avatarUrl ? user?.avatarUrl : "/src/assets/icons/profile_default_icon.png"}
-                />
-                Profile
-            </Link>
-
-            <div className="nav-btn more-container" onMouseEnter={openMore} onMouseLeave={closeMore}>
-                <div className="more-toggle">
-                    <img className="nav-icon" src="/src/assets/icons/more.png" />
-                    <span>More</span>
-                </div>
-
-                <div
-                    className={`more-menu ${moreOpen ? "more-menu-open" : "more-menu-closed"}`}
-                    onMouseEnter={blockHide}
-                    role="menu"
-                    aria-hidden={!moreOpen}
+        <nav className={navClasses.join(" ")} aria-label="Primary navigation">
+            <div className="navbar__brand-row">
+                <Link to="/" className="nav-title" onClick={handleNavItemClick}>
+                    Vembo
+                </Link>
+                <button
+                    type="button"
+                    className="nav__toggle"
+                    onClick={toggleMobileMenu}
+                    aria-expanded={isMobileMenuOpen}
+                    aria-controls="primary-navigation"
                 >
-                    <Link to="/settings" className="more-menu-item" onClick={closeMoreImmediately}>
-                        Settings
-                    </Link>
+                    <span className="sr-only">
+                        {isMobileMenuOpen ? "Close navigation" : "Open navigation"}
+                    </span>
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                        {isMobileMenuOpen ? (
+                            <path
+                                fill="currentColor"
+                                d="M6.4 5.1 5 6.5 10.5 12 5 17.5l1.4 1.4L12 13.4l5.6 5.5 1.4-1.4L13.4 12l5.6-5.5-1.4-1.4L12 10.6z"
+                            />
+                        ) : (
+                            <path fill="currentColor" d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4z" />
+                        )}
+                    </svg>
+                </button>
+            </div>
+
+            <div className="navbar__menu" id="primary-navigation">
+                <Link
+                    to="/"
+                    className={`nav-btn ${selectedPage === 0 ? "nav-btn-selected" : ""}`}
+                    onClick={handleNavItemClick}
+                    aria-current={selectedPage === 0 ? "page" : undefined}
+                >
+                    <img className="nav-icon" src="/src/assets/icons/glacier.png" alt="Learn" loading="lazy" />
+                    Learn
+                </Link>
+                <Link
+                    to="/practice-hub"
+                    className={`nav-btn ${selectedPage === 1 ? "nav-btn-selected" : ""}`}
+                    onClick={handleNavItemClick}
+                    aria-current={selectedPage === 1 ? "page" : undefined}
+                >
+                    <img className="nav-icon" src="/src/assets/icons/practice.png" alt="Practice" loading="lazy" />
+                    Practice
+                </Link>
+                <Link
+                    to="/leaderboards"
+                    className={`nav-btn ${selectedPage === 2 ? "nav-btn-selected" : ""}`}
+                    onClick={handleNavItemClick}
+                    aria-current={selectedPage === 2 ? "page" : undefined}
+                >
+                    <img
+                        className="nav-icon"
+                        src="/src/assets/icons/leaderboards.png"
+                        alt="Leaderboards"
+                        loading="lazy"
+                    />
+                    Leaderboards
+                </Link>
+                <Link
+                    to="/quests"
+                    className={`nav-btn ${selectedPage === 3 ? "nav-btn-selected" : ""}`}
+                    onClick={handleNavItemClick}
+                    aria-current={selectedPage === 3 ? "page" : undefined}
+                >
+                    <img className="nav-icon" src="/src/assets/icons/chest.png" alt="Quests" loading="lazy" />
+                    Quests
+                </Link>
+                <Link
+                    to="/shop"
+                    className={`nav-btn ${selectedPage === 4 ? "nav-btn-selected" : ""}`}
+                    onClick={handleNavItemClick}
+                    aria-current={selectedPage === 4 ? "page" : undefined}
+                >
+                    <img className="nav-icon" src="/src/assets/icons/shop.png" alt="Shop" loading="lazy" />
+                    Shop
+                </Link>
+                <Link
+                    to={`/profile/${user?.nickName}`}
+                    className={`nav-btn ${selectedPage === 5 ? "nav-btn-selected" : ""}`}
+                    onClick={handleNavItemClick}
+                    aria-current={selectedPage === 5 ? "page" : undefined}
+                >
+                    <img
+                        className="nav-profile-icon"
+                        src={user?.avatarUrl ? user?.avatarUrl : "/src/assets/icons/profile_default_icon.png"}
+                        alt="Profile avatar"
+                        loading="lazy"
+                    />
+                    Profile
+                </Link>
+
+                <div className="more-container" onMouseEnter={openMore} onMouseLeave={closeMore}>
+                    <button
+                        type="button"
+                        className={`nav-btn more-toggle ${moreOpen ? "nav-btn-selected" : ""}`}
+                        onClick={toggleMore}
+                        aria-expanded={moreOpen}
+                        aria-controls="more-menu"
+                    >
+                        <img className="nav-icon" src="/src/assets/icons/more.png" alt="More" loading="lazy" />
+                        <span>More</span>
+                    </button>
 
                     <div
-                        className="more-menu-item"
-                        onClick={() => {
-                            handleLogout();
-                            closeMoreImmediately();
-                        }}
+                        id="more-menu"
+                        className={`more-menu ${moreOpen ? "more-menu-open" : "more-menu-closed"}`}
+                        onMouseEnter={blockHide}
+                        role="menu"
+                        aria-hidden={!moreOpen}
                     >
-                        Log out
-                    </div>
+                        <Link to="/settings" className="more-menu-item" onClick={handleNavItemClick}>
+                            Settings
+                        </Link>
 
-                    <Link to="/help" className="more-menu-item" onClick={closeMoreImmediately}>
-                        Help
-                    </Link>
+                        <button
+                            type="button"
+                            className="more-menu-item"
+                            onClick={() => {
+                                handleLogout();
+                                handleNavItemClick();
+                            }}
+                        >
+                            Log out
+                        </button>
+
+                        <Link to="/help" className="more-menu-item" onClick={handleNavItemClick}>
+                            Help
+                        </Link>
+                    </div>
                 </div>
             </div>
         </nav>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,6 +111,10 @@ body {
     }
 }
 
+.auth-page {
+    padding: clamp(1.5rem, 6vw, 3.5rem);
+}
+
 /* ===== Form ===== */
 .signup-form {
     display: flex;
@@ -140,6 +144,11 @@ body {
     /* font-size: 2.25rem; */
     font-size: 2rem; /* трохи зменшено */
     margin: 0;
+}
+
+.signup-title {
+    font-size: var(--step-3);
+    margin-block: var(--space-2);
 }
 @media (max-width: 767.98px) {
     .signup-title {
@@ -173,6 +182,11 @@ body {
     }
 }
 
+.signup-subtitle {
+    font-size: var(--step-0);
+    margin-block: var(--space-1);
+}
+
 .text-medium-blue {
     color: var(--medium-blue);
 }
@@ -185,6 +199,10 @@ body {
     width: 100%;
 }
 
+.form-block {
+    gap: var(--space-4);
+}
+
 /* ===== Form Fields ===== */
 .form-fields {
     display: flex;
@@ -193,12 +211,22 @@ body {
     width: 100%;
 }
 
+.form-fields {
+    gap: var(--space-3);
+}
+
 .input-group {
     display: flex;
     flex-direction: column;
     gap: 4px;
     height: 60px;
     width: 100%;
+}
+
+.input-group {
+    gap: var(--space-1);
+    min-block-size: auto;
+    height: auto;
 }
 
 /* ===== Container (Input with border) ===== */
@@ -219,6 +247,11 @@ body {
     border-radius: 15px;
 }
 
+.input-box {
+    min-block-size: clamp(2.75rem, 6vh, 3.5rem);
+    border-radius: var(--radius-lg);
+}
+
 /* ===== Input ===== */
 .input {
     position: relative;
@@ -233,6 +266,13 @@ body {
     /* font-size: 1.25rem; */
     font-size: 1.125rem; /* трохи зменшено */
     color: var(--medium-blue);
+}
+
+.input {
+    min-block-size: clamp(2.75rem, 6vh, 3.5rem);
+    padding-inline: var(--space-3);
+    font-size: var(--step-0);
+    border-radius: var(--radius-lg);
 }
 
 .input::placeholder {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -47,6 +47,7 @@
 }
 
 :root {
+    color-scheme: dark;
     --frost-blue: #b4deff;
     --ice-white: #f5faff;
     --glacier-blue: #71b4d4;
@@ -64,11 +65,11 @@
     --text-color-light: var(--white);
     --text-color-dark: var(--polar-navy);
 
-    --navbar-border-color: var(var(--ice-white));
+    --navbar-border-color: rgba(245, 250, 255, 0.4);
     --nav-title-color: var(--frost-blue);
-    --nav-btn-border-color: var(--polar-navy);
+    --nav-btn-border-color: color-mix(in srgb, var(--polar-navy) 70%, transparent);
     --nav-btn-border-color-active: var(--glacier-blue);
-    --nav-btn-border-color-hover: rgba(255, 255, 255, 0.01);
+    --nav-btn-border-color-hover: rgba(255, 255, 255, 0.08);
     --nav-btn-background-hover: rgba(255, 255, 255, 0.17);
 
     --guidebook-btn-border-color: rgba(15, 32, 56, 0.63);
@@ -84,19 +85,53 @@
     --level-btn-item-active: var(--steel-blue);
 
     --insight-background: linear-gradient(#2ee6c3, #3c4dff, #a259ff);
+
+    --container-max: 80rem;
+    --space-1: clamp(0.25rem, 0.22rem + 0.2vw, 0.5rem);
+    --space-2: clamp(0.5rem, 0.4rem + 0.6vw, 0.9rem);
+    --space-3: clamp(0.75rem, 0.6rem + 0.9vw, 1.35rem);
+    --space-4: clamp(1rem, 0.8rem + 1.2vw, 1.75rem);
+    --space-5: clamp(1.5rem, 1.2rem + 1.8vw, 2.5rem);
+    --space-6: clamp(2rem, 1.6rem + 2.4vw, 3.5rem);
+
+    --step--1: clamp(0.875rem, 0.83rem + 0.2vw, 0.95rem);
+    --step-0: clamp(1rem, 0.94rem + 0.4vw, 1.125rem);
+    --step-1: clamp(1.25rem, 1.05rem + 0.8vw, 1.6rem);
+    --step-2: clamp(1.5rem, 1.2rem + 1.2vw, 2rem);
+    --step-3: clamp(1.85rem, 1.5rem + 1.8vw, 2.6rem);
+    --step-4: clamp(2.4rem, 2rem + 2.5vw, 3.4rem);
+
+    --radius-sm: 0.5rem;
+    --radius-md: 0.75rem;
+    --radius-lg: 0.9375rem;
+    --shadow-soft: 0 8px 32px rgba(0, 0, 0, 0.18);
 }
 
-html,
+html {
+    box-sizing: border-box;
+    font-family: "Rubik", sans-serif;
+    font-size: 16px;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: inherit;
+}
+
 body,
 #root {
-    height: 100%;
+    min-block-size: 100vh;
+}
+
+body {
     margin: 0;
-    padding: 0;
     font-family: "Rubik", sans-serif;
-    background-color: var(--background);
+    font-size: var(--step-0);
+    line-height: 1.6;
     color: var(--text-color-light);
-    letter-spacing: 0;
-    line-height: normal;
+    background: var(--background);
+    text-rendering: optimizeLegibility;
 }
 
 h1,
@@ -106,25 +141,71 @@ h4,
 h5,
 h6 {
     font-weight: 700;
+    line-height: 1.2;
+}
+
+h1 {
+    font-size: var(--step-4);
+}
+
+h2 {
+    font-size: var(--step-3);
+}
+
+h3 {
+    font-size: var(--step-2);
+}
+
+p {
+    font-size: var(--step-0);
+    margin-block: var(--space-2);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+img,
+picture,
+svg,
+video,
+canvas,
+iframe {
+    display: block;
+    max-inline-size: 100%;
+    block-size: auto;
+}
+
+button,
+input,
+select,
+textarea {
+    font: inherit;
+    color: inherit;
+    min-block-size: clamp(2.5rem, 6vh, 3.25rem);
+    border-radius: var(--radius-lg);
+    border: 1px solid transparent;
 }
 
 button {
-    padding: 10px 60px;
-    font-size: 24px;
-    border-radius: 15px;
-    border-width: 2px 2px 5px 2px;
-    border-style: solid;
+    padding-inline: clamp(1rem, 4vw, 2.75rem);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    cursor: pointer;
     user-select: none;
+    transition: transform 0.2s ease, filter 0.2s ease, box-shadow 0.2s ease;
 }
 
 button:enabled:hover {
-    filter: brightness(1.1);
+    filter: brightness(1.05);
 }
 
 button:not(:disabled):active {
+    transform: translateY(2px);
     box-shadow: none;
-    margin-top: 4px;
-    margin-bottom: -4px;
 }
 
 .fade-in {
@@ -152,10 +233,8 @@ button:not(:disabled):active {
 
 .password-field {
     display: flex;
-    height: 60px;
     flex-direction: column;
-    align-items: flex-start;
-    gap: 4px;
+    gap: var(--space-1);
     align-self: stretch;
 }
 
@@ -164,17 +243,17 @@ button:not(:disabled):active {
 }
 
 .button {
-    display: flex;
-    width: 230px;
-    height: 60px;
-    padding: 20px 211px;
-    border-radius: 15px;
-    border: 2px solid var(--Glacier-Blue, #71b4d4);
+    display: inline-flex;
+    inline-size: min(100%, 14.375rem);
+    min-block-size: clamp(2.5rem, 6vh, 3.25rem);
+    padding-inline: var(--space-3);
+    border-radius: var(--radius-lg);
+    border: 2px solid var(--glacier-blue);
     box-shadow: 1px 4px 1px 0px #71b4d4;
-    background: var(--Ice-White, #f5faff);
+    background: var(--ice-white);
     justify-content: center;
     align-items: center;
-    gap: 10px;
+    gap: var(--space-1);
 }
 
 .hidden {
@@ -185,11 +264,25 @@ button:not(:disabled):active {
     opacity: 0 !important;
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .container {
-    display: flex;
-    width: 100%;
-    align-items: center;
-    flex-direction: column;
+    inline-size: min(100%, var(--container-max));
+    margin-inline: auto;
+    padding-inline: clamp(1rem, 4vw, 1.5rem);
+    padding-block: var(--space-4);
+    display: grid;
+    gap: var(--space-4);
 }
 
 body.settings-page .container {
@@ -198,93 +291,220 @@ body.settings-page .container {
 
 .header {
     display: flex;
-    width: 100%;
+    inline-size: 100%;
     justify-content: end;
 }
 
 .header-item {
-    margin: 20px;
+    margin: var(--space-3);
 }
 
 .grid-container {
     --grid-background: none;
+    --app-grid-template: minmax(0, 1fr);
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+        "nav"
+        "main"
+        "sidebar";
+    min-block-size: 100svh;
     width: 100%;
-    min-height: 100vh;
-    grid-template-columns: 320px 5fr 3fr;
     background: var(--grid-background);
+}
+
+.grid-container > .container {
+    grid-area: main;
+}
+
+.grid-container[data-sidebar-hidden="true"] {
+    grid-template-areas:
+        "nav"
+        "main";
+}
+
+.grid-container[data-nav-hidden="true"] {
+    grid-template-areas:
+        "main"
+        "sidebar";
+}
+
+.grid-container[data-nav-hidden="true"][data-sidebar-hidden="true"] {
+    grid-template-areas: "main";
+}
+
+@media (min-width: 48rem) {
+    .grid-container {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-areas:
+            "nav"
+            "main"
+            "sidebar";
+    }
+}
+
+@media (min-width: 64rem) {
+    .grid-container {
+        grid-template-columns: var(--app-grid-template, 18rem 1fr);
+        grid-template-areas:
+            "nav main"
+            "nav sidebar";
+        column-gap: var(--space-4);
+    }
+
+    .grid-container[data-sidebar-hidden="true"] {
+        grid-template-areas: "nav main";
+    }
+
+    .grid-container[data-nav-hidden="true"] {
+        grid-template-columns: var(--app-grid-template, minmax(0, 1fr));
+        grid-template-areas:
+            "main"
+            "sidebar";
+    }
+
+    .grid-container[data-nav-hidden="true"][data-sidebar-hidden="true"] {
+        grid-template-areas: "main";
+    }
+}
+
+@media (min-width: 80rem) {
+    .grid-container {
+        grid-template-areas: "nav main sidebar";
+        grid-template-columns: var(--app-grid-template, 18rem 1fr 20rem);
+    }
+
+    .grid-container[data-nav-hidden="true"] {
+        grid-template-areas: "main sidebar";
+        grid-template-columns: var(--app-grid-template, minmax(0, 1fr) minmax(clamp(17rem, 28vw, 22rem), 1fr));
+    }
 }
 
 /* =========================================================================================================================================================================== */
 /* ============================================================================== Navigation Bar ============================================================================= */
 /* =========================================================================================================================================================================== */
 
+
 .navbar {
-    display: flex;
-    flex-direction: column;
+    grid-area: nav;
     position: sticky;
-    top: 0;
-    z-index: 3;
-    height: 100vh;
-    border-right: 1px solid var(--ice-white);
-    background-color: var(--polar-navy);
+    inset-block-start: 0;
+    inset-inline: 0;
+    z-index: 10;
+    display: grid;
+    align-content: start;
+    gap: var(--space-3);
+    padding: var(--space-3);
+    padding-block-end: var(--space-4);
+    border-bottom: 1px solid var(--navbar-border-color);
+    background: linear-gradient(180deg, rgba(15, 32, 56, 0.95), rgba(15, 32, 56, 0.85));
+    backdrop-filter: blur(18px);
+}
+
+.navbar.is-open {
+    box-shadow: var(--shadow-soft);
+}
+
+.navbar__brand-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
 }
 
 .nav-title {
-    margin-top: 8px;
-    margin-left: 51px;
-    font-size: 48px;
-    line-height: normal;
     font-family: "Atma", sans-serif;
+    font-size: var(--step-3);
     color: var(--nav-title-color);
+    letter-spacing: 0.05em;
+    margin: 0;
+}
+
+.nav__toggle {
+    inline-size: 44px;
+    block-size: 44px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--nav-btn-border-color);
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--ice-white);
+    padding: 0;
+}
+
+.nav__toggle svg {
+    inline-size: 1.5rem;
+    block-size: 1.5rem;
+}
+
+.navbar__menu {
+    display: grid;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    visibility: hidden;
+    opacity: 0;
+    transform: translateY(-0.5rem);
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.navbar.is-open .navbar__menu {
+    visibility: visible;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
 }
 
 .nav-btn {
-    display: flex;
-    width: 277px;
-    height: 63px;
-    margin: 4px;
-    align-self: center;
+    display: inline-flex;
     align-items: center;
-    font-size: 20px;
-    font-family: "Rubik", sans-serif;
+    gap: var(--space-2);
+    inline-size: 100%;
+    padding: clamp(0.75rem, 2vw, 1rem) var(--space-3);
+    min-block-size: clamp(2.75rem, 6vh, 3.5rem);
+    border-radius: var(--radius-lg);
+    border: 1px solid transparent;
+    background: transparent;
+    font-size: var(--step--1);
     font-weight: 700;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    border-radius: 15px;
-    border-width: 2px;
-    border-color: var(--nav-btn-border-color);
-    box-sizing: border-box;
+    color: var(--ice-white);
+    transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
 }
 
-.nav-btn:hover {
-    border-color: var(--nav-btn-border-color-hover);
+.nav-btn:hover,
+.nav-btn:focus-visible {
     background-color: var(--nav-btn-background-hover);
+    border-color: var(--nav-btn-border-color-hover);
+}
+
+.nav-btn:focus-visible,
+.nav__toggle:focus-visible,
+.more-menu-item:focus-visible {
+    outline: 3px solid var(--glacier-blue);
+    outline-offset: 3px;
 }
 
 .nav-btn-selected {
     border-color: var(--nav-btn-border-color-active);
-}
-
-.nav-btn-selected:hover {
-    border-color: var(--nav-btn-border-color-active);
-    background-color: var(--nav-btn-border-color);
+    background-color: color-mix(in srgb, var(--glacier-blue) 20%, transparent);
+    box-shadow: inset 0 0 0 1px rgba(113, 180, 212, 0.4);
 }
 
 .nav-icon {
-    margin-left: 19px;
-    margin-right: 24px;
-    width: 52px;
+    inline-size: clamp(1.75rem, 5vw, 2.75rem);
+    block-size: clamp(1.75rem, 5vw, 2.75rem);
+    flex-shrink: 0;
+    aspect-ratio: 1;
 }
 
 .nav-profile-icon {
-    padding-left: 10px;
-    padding-right: 10px;
-    margin-left: 19px;
-    margin-right: 24px;
-    width: 52px;
-    object-fit: cover;
-    height: 32px;
+    inline-size: clamp(1.75rem, 5vw, 2.75rem);
+    block-size: clamp(1.75rem, 5vw, 2.75rem);
     border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
 }
 
 .more-container {
@@ -292,52 +512,66 @@ body.settings-page .container {
 }
 
 .more-toggle {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
-    width: 100%;
+    justify-content: space-between;
+    gap: var(--space-2);
+    inline-size: 100%;
+}
+
+.more-toggle {
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    padding: 0;
 }
 
 .more-menu {
-    position: absolute;
-    padding-top: 14px;
-    padding-bottom: 14px;
-    width: 261px;
-    top: -15px;
-    left: 285px;
-    color: #ffffff;
-    border: 1px solid #71b4d4;
-    border-radius: 15px;
-    background-color: var(--polar-navy);
-    transition: all 0.2s ease-in-out;
+    display: grid;
+    gap: var(--space-1);
+    padding: var(--space-2);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--glacier-blue);
+    background: rgba(15, 32, 56, 0.95);
+    color: var(--ice-white);
+    box-shadow: var(--shadow-soft);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-0.5rem);
+    pointer-events: none;
 }
 
-.more-menu-closed {
-    visibility: hidden;
-    opacity: 0;
-    transform: translateX(-10px);
+.more-menu {
+    margin-top: var(--space-2);
 }
 
 .more-menu-open {
-    display: block;
     opacity: 1;
+    visibility: visible;
     transform: translateY(0);
+    pointer-events: auto;
+}
+
+.more-menu-closed {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
 }
 
 .more-menu-item {
     display: block;
-    padding: 11.5px 65px;
-    letter-spacing: 1%;
-    color: #ffffff;
-    text-decoration: none;
-    cursor: pointer;
-    font-weight: 700;
+    padding: clamp(0.75rem, 2vw, 1rem);
+    border-radius: var(--radius-md);
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    border: none;
-    width: 100%;
-    text-align: center;
-    font-size: 20px;
     font-weight: 700;
+    color: inherit;
+    text-align: center;
+    border: none;
+    background: transparent;
+    cursor: pointer;
 }
 
 .more-menu-item[type="button"] {
@@ -346,19 +580,71 @@ body.settings-page .container {
 }
 
 .more-menu-item:hover,
-.more-menu-item:focus {
-    background-color: rgba(255, 255, 255, 0.06);
+.more-menu-item:focus-visible {
+    background-color: rgba(255, 255, 255, 0.08);
 }
 
-/* =========================================================================================================================================================================== */
+@media (min-width: 48rem) {
+    .navbar {
+        min-block-size: 100svh;
+        padding-inline: clamp(1.5rem, 3vw, 2.25rem);
+        padding-block: var(--space-5);
+        border-bottom: none;
+        border-right: 1px solid var(--navbar-border-color);
+        background: linear-gradient(180deg, rgba(15, 32, 56, 0.95), rgba(15, 32, 56, 0.8));
+    }
+
+    .navbar__brand-row {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-4);
+    }
+
+    .nav-title {
+        font-size: var(--step-4);
+    }
+
+    .nav__toggle {
+        display: none;
+    }
+
+    .navbar__menu {
+        visibility: visible;
+        opacity: 1;
+        transform: none;
+        pointer-events: auto;
+        gap: var(--space-2);
+    }
+
+    .more-menu {
+        position: absolute;
+        inset-inline-start: calc(100% + var(--space-2));
+        inset-block-start: 0;
+        min-inline-size: clamp(14rem, 20vw, 16rem);
+    }
+}
+
+@media (min-width: 80rem) {
+    .navbar__menu {
+        gap: var(--space-3);
+    }
+
+    .nav-btn {
+        font-size: var(--step-0);
+    }
+}
+
 /* ============================================================================== Unit Header Card ============================================================================ */
 /* =========================================================================================================================================================================== */
+
 
 .unit-header-card__container {
     position: sticky;
     top: 0px;
     z-index: 2;
     transition: all 0.4s ease-in-out 0.4s;
+    padding-inline: var(--space-2);
+    padding-block: var(--space-3);
 }
 
 .unit-header-card__shadow {
@@ -367,74 +653,79 @@ body.settings-page .container {
 }
 
 .unit-header-card {
-    width: 744px;
-    height: 171px;
+    inline-size: min(100%, clamp(20rem, 85vw, 46rem));
+    min-block-size: clamp(10rem, 32vw, 13rem);
+    margin-inline: auto;
     overflow: hidden;
     background-color: var(--mint);
     color: var(--text-color-dark);
     border-radius: 20px;
+    padding: var(--space-3) clamp(1.25rem, 4vw, 2.5rem);
+    display: grid;
+    gap: var(--space-3);
 }
 
 .current-path {
     display: flex;
-    margin-top: 32px;
-    margin-left: 28px;
     align-items: center;
+    gap: var(--space-2);
+    margin: 0;
 }
 
 .current-path__icon {
-    width: 32px;
-    height: 32px;
-    margin-right: 8px;
-    opacity: 79%;
+    inline-size: clamp(1.5rem, 5vw, 2rem);
+    block-size: clamp(1.5rem, 5vw, 2rem);
+    opacity: 0.79;
 }
 
 .current-path__title {
-    font-size: 20px;
+    font-size: var(--step--1);
     font-weight: 500;
     text-transform: uppercase;
-    opacity: 79%;
+    opacity: 0.85;
 }
 
 .unit-header {
     display: flex;
-    margin-top: 8px;
-    margin-left: 28px;
-    margin-right: 34px;
+    flex-wrap: wrap;
+    gap: var(--space-2);
     justify-content: space-between;
+    align-items: center;
+    margin: 0;
 }
 
 .unit-header__title {
-    width: 371px;
-    font-size: 32px;
-    line-height: 36px;
+    inline-size: min(100%, 32ch);
+    font-size: var(--step-2);
+    line-height: 1.25;
     font-weight: 700;
 }
 
 .unit-header__guidebook-btn {
-    display: flex;
-    width: 186px;
-    height: 80px;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     text-transform: uppercase;
-    border-radius: 21px;
-    border-width: 2px 2px 5px 2px;
+    min-inline-size: clamp(10rem, 42vw, 14rem);
+    min-block-size: clamp(3rem, 6vh, 4.5rem);
+    padding-inline: var(--space-3);
+    border-radius: var(--radius-lg);
+    border-width: 1px;
     border-style: solid;
     border-color: var(--guidebook-btn-border-color);
+    gap: var(--space-2);
 }
 
 .guidebook-btn__icon {
-    width: 40px;
-    height: 40px;
+    inline-size: clamp(2rem, 6vw, 2.5rem);
+    block-size: clamp(2rem, 6vw, 2.5rem);
 }
 
 .guidebook-btn__title {
-    font-size: 20px;
+    font-size: var(--step-0);
     font-weight: 600;
 }
 
-/* =========================================================================================================================================================================== */
 /* ================================================================================ Unit Title =============================================================================== */
 /* =========================================================================================================================================================================== */
 
@@ -453,12 +744,24 @@ body.settings-page .container {
     gap: 18px;
 }
 
+.unit-title-container {
+    margin-top: var(--space-5);
+    padding-inline: var(--space-2);
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
 .unit-title-container__hr {
     flex: 1;
     height: 3px;
     border: none;
     background-color: var(--unit-title-element-color);
     margin: 0 auto;
+}
+
+.unit-title-container__h2 {
+    font-size: var(--step-0);
+    line-height: 1.4;
 }
 
 .unit-title-container__h2 {
@@ -589,6 +892,23 @@ body.settings-page .container {
     transition: all 0.3s ease-in-out;
 }
 
+.sidebar-top {
+    grid-area: sidebar;
+    inline-size: min(100%, clamp(18rem, 32vw, 22rem));
+    padding-inline: clamp(1rem, 4vw, 1.75rem);
+    padding-block: var(--space-4);
+    margin-inline: auto;
+    top: var(--space-4);
+}
+
+.sidebar {
+    position: sticky;
+    top: var(--space-4);
+    bottom: auto;
+    display: grid;
+    gap: var(--space-3);
+}
+
 body.hide-sidebar .sidebar,
 body.hide-sidebar .sidebar-top {
     display: none !important;
@@ -621,6 +941,26 @@ body.hide-sidebar .sidebar-top {
     color: #71b4d4;
 }
 
+.stats {
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    justify-content: center;
+}
+
+.stats-item {
+    gap: var(--space-1);
+}
+
+.stats-icon {
+    inline-size: clamp(1.75rem, 5vw, 2.5rem);
+    block-size: clamp(1.75rem, 5vw, 2.5rem);
+}
+
+.stats-value {
+    margin: 0;
+    font-size: var(--step-0);
+}
+
 .heart {
     color: #f44336;
 }
@@ -634,6 +974,13 @@ body.hide-sidebar .sidebar-top {
     margin-top: 32px;
     flex-direction: column;
     gap: 24px;
+}
+
+.card-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+    gap: clamp(1rem, 3vw, 1.5rem);
+    margin-top: var(--space-4);
 }
 
 /* =========================================================================================================================================================================== */
@@ -651,8 +998,30 @@ body.hide-sidebar .sidebar-top {
     padding-bottom: 29px;
 }
 
+.insight-card,
+.leaderboard-card,
+.daily-quests-card,
+.what-are-leaderboards-card {
+    padding: clamp(1.25rem, 3vw, 1.75rem);
+    border-radius: var(--radius-lg);
+    display: grid;
+    gap: var(--space-2);
+}
+
 .insight-card__block {
     display: flex;
+}
+
+.insight-card__block {
+    display: grid;
+    gap: var(--space-2);
+    align-items: center;
+}
+
+@media (min-width: 48rem) {
+    .insight-card__block {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
 }
 
 .insight-card__img {
@@ -667,14 +1036,34 @@ body.hide-sidebar .sidebar-top {
     margin-top: 16px;
 }
 
+.insight-card__img {
+    inline-size: min(100%, 7.5rem);
+    margin-bottom: var(--space-1);
+}
+
+.insight-card__bear-img {
+    inline-size: clamp(5rem, 18vw, 7rem);
+    block-size: auto;
+    margin-top: var(--space-2);
+}
+
 .insight-card__title,
 .leaderboard-card__title {
     font-size: 24px;
     font-weight: 700;
 }
 
+.insight-card__title,
+.leaderboard-card__title {
+    font-size: var(--step-1);
+}
+
 .insight-card__info {
     font-size: 20px;
+}
+
+.insight-card__info {
+    font-size: var(--step-0);
 }
 
 .insight-btn {
@@ -693,6 +1082,13 @@ body.hide-sidebar .sidebar-top {
     cursor: pointer;
 }
 
+.insight-btn {
+    min-block-size: clamp(2.75rem, 6vh, 3.5rem);
+    margin-top: var(--space-1);
+    border-radius: var(--radius-lg);
+    font-size: var(--step--1);
+}
+
 .insight-btn:not(:disabled):active {
     margin-top: 9px;
 }
@@ -704,6 +1100,25 @@ body.hide-sidebar .sidebar-top {
 .leaderboard-inactive-card__content {
     display: flex;
     margin-top: 44px;
+}
+
+.leaderboard-inactive-card__content,
+.leaderboard-card__block,
+.leaderboard-card__content {
+    display: grid;
+    gap: var(--space-2);
+    align-items: center;
+}
+
+@media (min-width: 48rem) {
+    .leaderboard-inactive-card__content,
+    .leaderboard-card__content {
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    .leaderboard-card__block {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
 }
 
 .leaderboard-card__block {
@@ -728,6 +1143,12 @@ body.hide-sidebar .sidebar-top {
     font-weight: 700;
 }
 
+.leaderboard-card__league-title {
+    margin-bottom: var(--space-1);
+    font-size: var(--step--1);
+    letter-spacing: 0.08em;
+}
+
 .leaderboard-inactive-card__img {
     width: 56px;
     height: 62px;
@@ -743,9 +1164,20 @@ body.hide-sidebar .sidebar-top {
     margin-bottom: 32px;
 }
 
+.leaderboard-card__badge-img {
+    inline-size: clamp(4.5rem, 18vw, 6.5rem);
+    block-size: auto;
+    margin: 0 auto;
+}
+
 .leaderboard-card__info {
     width: 277px;
     font-size: 20px;
+}
+
+.leaderboard-card__info {
+    inline-size: auto;
+    font-size: var(--step-0);
 }
 
 .leaderboard-card__btn {
@@ -761,6 +1193,13 @@ body.hide-sidebar .sidebar-top {
     font-weight: 700;
     text-transform: uppercase;
     cursor: pointer;
+}
+
+.leaderboard-card__btn {
+    min-block-size: clamp(3.25rem, 6vh, 4.75rem);
+    margin-bottom: var(--space-2);
+    border-radius: var(--radius-lg);
+    font-size: var(--step-0);
 }
 
 .leaderboard-card__btn:not(:disabled):hover {


### PR DESCRIPTION
## Summary
- add fluid spacing and typography tokens plus a unified container grid to support mobile-first layouts
- rebuild the primary navigation component and styles with an accessible mobile drawer and desktop sidebar behaviour
- update key content blocks (unit header, cards, stats, and auth forms) to use responsive sizing, gaps, and touch-friendly controls